### PR TITLE
fix js error flatpickr

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,7 +8,6 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 
-
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
 // or the `imagePath` JavaScript helper below.
@@ -16,26 +15,18 @@ require("channels")
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
 
-
-// ----------------------------------------------------
-// Note(lewagon): ABOVE IS RAILS DEFAULT CONFIGURATION
-// WRITE YOUR OWN JS STARTING FROM HERE 👇
-// ----------------------------------------------------
-
 // External imports
 import "bootstrap";
 
 // Internal imports, e.g:
-// import { initSelect2 } from '../components/init_select2';
 import { initAutocomplete } from "../plugins/init_autocomplete";
 import { meteo } from "../components/meteo";
 import { loadDynamicBannerText } from "../components/banner";
 import flatpickr from "../plugins/flatpickr";
+
 document.addEventListener('turbolinks:load', () => {
   // Call your functions here, e.g:
-  // initSelect2();
   initAutocomplete();
   meteo();
   loadDynamicBannerText();
-  calendrier();
 });

--- a/app/javascript/plugins/flatpickr.js
+++ b/app/javascript/plugins/flatpickr.js
@@ -1,10 +1,3 @@
 import flatpickr from "flatpickr";
 
-
-const calendrier = () => {
-  const dateInput = document.querySelector(".flatpickr").flatpickr({
-    mode: 'range',
-  });
-};
-
 flatpickr(".datepicker", {});


### PR DESCRIPTION
- Dans la fichier flatpickr.js vous aviez entouré le code relatif à flatpickr dans une fonction appelée "calendar", que vous appeliez ensuite dans application.js. Ce n'est pas nécessaire et ça crée une erreur récurrente en console, donc je l'ai supprimée