### PR TITLE
fix js error typed text on banner

### DIFF
--- a/app/javascript/components/banner.js
+++ b/app/javascript/components/banner.js
@@ -1,11 +1,14 @@
 import Typed from 'typed.js';
 
 const loadDynamicBannerText = () => {
-  new Typed('#banner-typed-text', {
-    strings: ["clients","agenda", "tâches", "priorités", "devis", "factures", "alertes"],
-    typeSpeed: 60,
-    loop: true
-  });
+  const typedText = document.getElementById("banner-typed-text");
+  if (typedText) {
+    new Typed('#banner-typed-text', {
+      strings: ["clients","agenda", "tâches", "priorités", "devis", "factures", "alertes"],
+      typeSpeed: 60,
+      loop: true
+    });
+  }
 }
 
 export { loadDynamicBannerText };


### PR DESCRIPTION
Vous aviez une erreur JS relative au typed text de la banner. Celui-ci se lançait sur toutes les pages et buguait car il ne trouvait pas la div ayant l'id "banner-typed-text". J'ai mis la fonction dans un "if banner typed text est présent sur la page" pour réparer cela.