### PR TITLE
fix cloudinary problem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,10 +37,12 @@ gem 'flatpickr', '~> 2.3', '>= 2.3.5.0'
 gem 'autoprefixer-rails'
 gem 'font-awesome-sass'
 gem 'simple_form'
-group :development, :test do  gem 'pry-byebug'
+gem 'cloudinary', '~> 1.12.0'
+
+group :development, :test do
+  gem 'pry-byebug'
   gem 'pry-rails'
   gem 'dotenv-rails'
-  gem 'cloudinary', '~> 1.12.0'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end


### PR DESCRIPTION
Dans le gemfile, vous aviez mis la gem cloudinary dans "group :development, :test do" donc elle ne fonctionnait qu'en local. Je l'ai sortie de là pour qu'elle puisse fonctionner à la fois en local et en production.
